### PR TITLE
Add option for sequential frame naming and fix format dependent file extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 tests/images/
 .vscode/
+.idea/

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ class PuppeteerMassScreenshots {
     }
 
     async stop() {
+        this.frameNumber = undefined;
         return this.client.send('Page.stopScreencast');
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { join } = require('path');
 const fs = require('fs').promises;
-const emptyFunction = async() => {};
+const emptyFunction = async() => {/**/};
 const defaultAfterWritingNewFile = async(filename) => console.log(`${filename} was written`);
 
 class PuppeteerMassScreenshots {
@@ -14,8 +14,10 @@ class PuppeteerMassScreenshots {
         afterWritingImageFile: defaultAfterWritingNewFile,
         beforeAck: emptyFunction,
         afterAck: emptyFunction,
+        isSequentialFrameNaming: false,
         ...options
     }
+        this.isSequentialFrameNaming = runOptions.isSequentialFrameNaming;
         this.page = page;
         this.outputFolder = outputFolder;
         this.client = await this.page.target().createCDPSession();
@@ -37,7 +39,9 @@ class PuppeteerMassScreenshots {
     }
 
     async writeImageFilename(data) {
-        const filename = join(this.outputFolder, Date.now().toString() + '.jpg');
+        this.frameNumber = this.frameNumber === undefined ? 0 : this.frameNumber + 1;
+        const basename = this.isSequentialFrameNaming ? 'frame' + this.frameNumber.toString().padStart(6, '0') : Date.now();
+        const filename = join(this.outputFolder, basename + this.extension);
         await fs.writeFile(filename, data, 'base64');
         return filename;
     }
@@ -51,6 +55,7 @@ class PuppeteerMassScreenshots {
             everyNthFrame: 1,
             ...options
         };
+        this.extension = `.${startOptions.format}`
         return this.client.send('Page.startScreencast', startOptions);
     }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@ const fs = require('fs').promises;
 const emptyFunction = async() => {/**/};
 const defaultAfterWritingNewFile = async(filename) => console.log(`${filename} was written`);
 
+const assert = (value, message) => {
+    if (!value)
+        throw new Error(message);
+};
+
 class PuppeteerMassScreenshots {
     async init(
         page, 
@@ -45,6 +50,7 @@ class PuppeteerMassScreenshots {
     async writeImageFilename(data = this.cachedFrame) {
         if (!data) {
             data = await this.page.screenshot({
+                type: this.format,
                 clip: {
                     x: 0,
                     y: 0,
@@ -57,7 +63,7 @@ class PuppeteerMassScreenshots {
         if (!this.cachedFrame) this.cachedFrame = data;
         this.frameNumber = this.frameNumber === undefined ? 0 : this.frameNumber + 1;
         const basename = this.isSequentialFrameNaming ? 'frame' + this.frameNumber.toString().padStart(6, '0') : Date.now();
-        const filename = join(this.outputFolder, basename + this.extension);
+        const filename = join(this.outputFolder, basename + '.' + this.format);
         await fs.writeFile(filename, data, 'base64');
         return filename;
     }
@@ -71,7 +77,8 @@ class PuppeteerMassScreenshots {
             everyNthFrame: 1,
             ...options
         };
-        this.extension = `.${startOptions.format}`;
+        assert(startOptions.format === 'png' || startOptions.format === 'jpeg', 'Unknown options.format value: ' + startOptions.format);
+        this.format = startOptions.format;
         this.maxWidth = startOptions.maxWidth;
         this.maxHeight = startOptions.maxHeight;
         return this.client.send('Page.startScreencast', startOptions);

--- a/tests/openGoogleSequential.js
+++ b/tests/openGoogleSequential.js
@@ -1,0 +1,43 @@
+const PuppeteerMassScreenshots = require('../index');
+const screenshots = new PuppeteerMassScreenshots();
+const puppeteer = require('puppeteer');
+const { join } = require('path');
+
+/**
+ * Open google.com web page,
+ * take screen,
+ * input text,
+ * take screen,
+ * search for result,
+ * take screen,
+ * finish.
+ * Frames will be saved with sequential file names: file000000.jpeg - file000002.jpeg
+ *
+ * As another example, you can evaluate script and save frame in for loop:
+ * for (const i = 0; i < endLoop; i++) {
+ *     await page.evaluate(`myScript(${i})`);
+ *     await screenshots.writeImageFilename();
+ * }
+ */
+(async () => {
+    const browser = await puppeteer.launch({ headless: false });
+    const page = (await browser.pages())[0];
+    const screenshotsPath = join(__dirname, 'images');
+    await screenshots.init(page, screenshotsPath, {isSequentialFrameNaming: true});
+    await page.goto('https://google.com');
+    await page.setViewport({
+        width: 1920,
+        height: 1080
+    });
+    await screenshots.start();
+    const input = await page.$('input[name=q]');
+    await screenshots.writeImageFilename();
+    await input.type('puppeteer-mass-screenshots', { delay: 100 });
+    await screenshots.writeImageFilename();
+    await input.press('Enter');
+    await page.waitForNavigation({ waitUntil: 'networkidle0' });
+    await screenshots.writeImageFilename();
+    setTimeout(() => console.log('Done'), 3000);
+    await screenshots.stop();
+    await browser.close();
+  })();

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,6 +5,7 @@
   "main": "openGoogle.js",
   "scripts": {
     "init-images-path": "rm -rf ./images; mkdir -p ./images",
+    "test-sequential": "node ./openGoogleSequential.js",
     "test": "node ./openGoogle.js"
   },
   "repository": {


### PR DESCRIPTION
To name frames sequentially and manual save frame set init option `isSequentialFrameNaming` to `true` and call `screenshots.writeImageFilename()` without parameters. For example see `tests/openGoogleSequential.js`